### PR TITLE
Fix typo in pick language dialog

### DIFF
--- a/app/src/main/java/com/adamian/daypicture/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/adamian/daypicture/ui/main/MainFragment.kt
@@ -182,7 +182,7 @@ class MainFragment : Fragment() {
 
         return activity?.let {
             val builder = AlertDialog.Builder(it)
-            builder.setTitle("Pic a language")
+            builder.setTitle("Pick a language")
                 .setItems(languages,
                     DialogInterface.OnClickListener { dialog, which ->
                         if (which == 0) {


### PR DESCRIPTION
This fixes the typo in the Pick Language Dialog
<img width="309" alt="Screen Shot 2020-07-11 at 1 48 46 PM" src="https://user-images.githubusercontent.com/9751473/87233579-9ff23380-c37d-11ea-8352-6f58883b675c.png">
